### PR TITLE
Change goblin gang description

### DIFF
--- a/data/cards.json
+++ b/data/cards.json
@@ -624,7 +624,7 @@
     "rarity": "Common",
     "type": "Troop",
     "name": "Goblin Gang",
-    "description": "Spawns six Goblins - three with knives, three with spears - at a discounted Elixir cost. It's like a Goblin Value Pack!",
+    "description": "Spawns five Goblins - three with knives, two with spears - at a discounted Elixir cost. It's like a Goblin Value Pack!",
     "arena": 9,
     "elixirCost": 3,
     "order":70


### PR DESCRIPTION
In balance change 6/12/2017, the Goblin Gang only has 2 spear goblins; the description was changed to reflect this.