### PR TITLE
🔌 Add Zappies

### DIFF
--- a/data/cards.json
+++ b/data/cards.json
@@ -691,5 +691,14 @@
     "arena": 10,
     "elixirCost": 7, 
     "order": 77
+  },
+  {
+    "rarity": "Rare",
+    "type": "Troop",
+    "name": "Zappies",
+    "description": "Spawns a pack of miniature Zap machines. Who controls them...? Only the Master Builder knows.",
+    "arena": 11,
+    "elixirCost": 4,
+    "order": 80
   }
 ]


### PR DESCRIPTION
  #8 Zappies are available in the new arena (11)